### PR TITLE
Disable FEATURE_SPI_WAKELOCK, as on klte

### DIFF
--- a/drivers/fingerprint/vfs61xx.h
+++ b/drivers/fingerprint/vfs61xx.h
@@ -68,10 +68,6 @@
 /* Timeout value for polling DRDY signal assertion */
 #define DRDY_TIMEOUT_MS      40
 
-#ifdef ENABLE_SENSORS_FPRINT_SECURE
-#define FEATURE_SPI_WAKELOCK
-#endif
-
 /*
  * Definitions of structures which are used by IOCTL commands
  */


### PR DESCRIPTION
That wakelock is hold forever, thus disallowing deep sleep.  As on klte,
it's completely redundant and can just go away.

Signed-off-by: Corinna Vinschen <corinna@vinschen.de>